### PR TITLE
Create .gitignore Add .gitignore to exclude cachAdd .gitignore to exclude cache and temp filese and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Jupyter and Python cache
+__pycache__/
+*.pyc
+.ipynb_checkpoints/
+
+# Environment files
+.env
+*.env
+
+# OS-specific
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This pull request adds a .gitignore file to prevent unnecessary files like __pycache__, .env, and notebook checkpoints from being tracked. It improves reproducibility and keeps the repo clean.
